### PR TITLE
(fix) Parse "not created" status message

### DIFF
--- a/parseStatus.js
+++ b/parseStatus.js
@@ -1,0 +1,25 @@
+
+
+module.exports = function(status_text){
+  var lines = status_text.split('\n').slice(2).reduce(function(prev, curr) {
+      if(prev.length > 0 && prev[prev.length - 1].length === 0)
+          return prev;
+
+      prev.push(curr.trim());
+      return prev;
+  }, []);
+
+  lines.pop();
+
+  var re = /^(\S+)\s+(\S+\s?\S*)+\s+\((\S+)\)$/;
+
+  var statuses = {};
+  lines.forEach(function(line) {
+      var res = line.match(re);
+      statuses[res[1]] = {
+          status: res[2],
+          provider: res[3]
+      };
+  });
+  return statuses;
+}

--- a/test/parseStatus.js
+++ b/test/parseStatus.js
@@ -1,0 +1,17 @@
+
+var fs = require("fs");
+var expect = require('chai').expect;
+
+var exStats = fs.readFileSync("./test/status").toString();
+var ps = require("../parseStatus");
+
+describe("Vagrant status parsing", function(){
+  it("should parse all status information",function(){
+    var mach_stats = ps(exStats);
+    expect(Object.keys(mach_stats).length).to.equal(2);
+    expect(mach_stats["my_server"].status).to.equal("running");
+    expect(mach_stats["my_server"].provider).to.equal("docker");
+    expect(mach_stats["rethinkDB"].status).to.equal("not created");
+    expect(mach_stats["rethinkDB"].provider).to.equal("virtualbox");
+  });
+});

--- a/test/status
+++ b/test/status
@@ -1,0 +1,8 @@
+Current machine states:
+
+my_server            running (docker)
+rethinkDB                 not created (virtualbox)
+
+This environment represents multiple VMs. The VMs are all listed
+above with their current state. For more information about a specific
+VM, run `vagrant status NAME`.

--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,7 @@ describe('it should test node-vagrant', function() {
         var config = require('./example1.config.json');
         machine.init('ubuntu/trusty64', config, function(err, out) {
             expect(err).to.not.exist;
-            
+
             var origLoc = path.join(__dirname, 'Vagrantfile');
             var exampleLoc = path.join(__dirname, 'example1.Vagrantfile');
 


### PR DESCRIPTION
There was a problem with the status message "not created". I fixed the regexp and added a test. I had to extract the parseStatus function to properly test it. 

My editor automatically removed all the whitespaces on empty lines.. Hope that is okay.